### PR TITLE
feat: add `ap-southeast-5` region

### DIFF
--- a/.gitlab/datasources/regions.yaml
+++ b/.gitlab/datasources/regions.yaml
@@ -11,6 +11,7 @@ regions:
   - code: "ap-southeast-2"
   - code: "ap-southeast-3"
   - code: "ap-southeast-4"
+  - code: "ap-southeast-5"
   - code: "ap-northeast-1"
   - code: "ap-northeast-2"
   - code: "ap-northeast-3"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds `ap-southeast-5` region

### Motivation

We don't have any layers there

### Testing Guidelines

Manually deployed a layer to sandbox
<img width="707" alt="Screenshot 2024-10-17 at 2 23 22 PM" src="https://github.com/user-attachments/assets/428c99cf-289c-47d9-9fcd-b82065744ca8">

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
