### PR TITLE
 chore(gitlab): add `mx-central-1` and `ap-southeast-7` regions

### DIFF
--- a/.gitlab/datasources/regions.yaml
+++ b/.gitlab/datasources/regions.yaml
@@ -12,6 +12,7 @@ regions:
   - code: "ap-southeast-3"
   - code: "ap-southeast-4"
   - code: "ap-southeast-5"
+  - code: "ap-southeast-7"
   - code: "ap-northeast-1"
   - code: "ap-northeast-2"
   - code: "ap-northeast-3"
@@ -28,4 +29,5 @@ regions:
   - code: "il-central-1"
   - code: "me-south-1"
   - code: "me-central-1"
+  - code: "mx-central-1"
   - code: "sa-east-1"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds new regions from Mexico and Thailand

### Motivation

https://aws.amazon.com/blogs/aws/now-open-aws-mexico-central-region/
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html

### Testing Guidelines

N/A

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
