### PR TITLE
update list of `dd-trace-dotnet` files removed from layer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+# Set line endings to LF, even on Windows. Otherwise, execution within Docker fails.
+# See https://help.github.com/articles/dealing-with-line-endings/
+*.sh text eol=lf
+*.bash text eol=lf

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -19,7 +19,7 @@ RUN dpkg -i /tmp/tracer.deb
 
 WORKDIR /opt
 
-# remove some useless files in a serverless context to keep the package as small as possible
+# remove files unused in a serverless context to keep the package as small as possible
 RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/*.so && \
     rm -f datadog/loader.conf && \

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -20,18 +20,18 @@ RUN dpkg -i /tmp/tracer.deb
 WORKDIR /opt
 
 # remove some useless files in a serverless context to keep the package as small as possible
-RUN rm datadog/createLogPath.sh && \
-    rm datadog/*.so && \
-    rm datadog/loader.conf && \
-    rm datadog/**/loader.conf && \
-    rm datadog/**/libddwaf.so && \
-    rm datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
-    rm datadog/**/Datadog.Profiler.Native.so && \
-    rm datadog/**/Datadog.Trace.MSBuild.* && \
-    rm datadog/**/*.pdb && \
-    rm datadog/**/*.xml && \
-    rm datadog/dd-dotnet.sh && \
-    rm datadog/**/dd-dotnet && \
+RUN rm -f datadog/createLogPath.sh && \
+    rm -f datadog/*.so && \
+    rm -f datadog/loader.conf && \
+    rm -f datadog/**/loader.conf && \
+    rm -f datadog/**/libddwaf.so && \
+    rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
+    rm -f datadog/**/Datadog.Profiler.Native.so && \
+    rm -f datadog/**/Datadog.Trace.MSBuild.* && \
+    rm -f datadog/**/*.pdb && \
+    rm -f datadog/**/*.xml && \
+    rm -f datadog/dd-dotnet.sh && \
+    rm -f datadog/**/dd-dotnet && \
     rm -rf datadog/net461 && \
     rm -rf datadog/netstandard2.0 && \
     rm -rf datadog/netcoreapp3.1 && \

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -32,6 +32,7 @@ RUN rm datadog/createLogPath.sh && \
     rm datadog/**/*.xml && \
     rm datadog/dd-dotnet.sh && \
     rm datadog/**/dd-dotnet && \
+    rm -rf datadog/net461 && \
     rm -rf datadog/netstandard2.0 && \
     rm -rf datadog/netcoreapp3.1 && \
     rm -rf datadog/continuousprofiler

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -27,6 +27,7 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
     rm -f datadog/**/Datadog.Profiler.Native.so && \
     rm -f datadog/**/Datadog.Trace.MSBuild.* && \
+    rm -f datadog/**/libdatadog_profiling.so \
     rm -f datadog/**/*.pdb && \
     rm -f datadog/**/*.xml && \
     rm -f datadog/dd-dotnet.sh && \

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest as builder
+FROM ubuntu:latest AS builder
 ARG TRACER_VERSION
 ARG ARCH
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -25,9 +25,6 @@ RUN rm datadog/createLogPath.sh && \
     rm datadog/loader.conf && \
     rm datadog/**/loader.conf && \
     rm datadog/**/libddwaf.so && \
-    # Revise to use 'Datadog.Trace.ClrProfiler.Native.so' for profiling, which calls
-    # 'Datadog.Trace.Native.so' and 'Datadog.Trace.Profiler.so'.
-    rm datadog/**/Datadog.Trace.ClrProfiler.Native.so && \
     rm datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
     rm datadog/**/Datadog.Profiler.Native.so && \
     rm datadog/**/Datadog.Trace.MSBuild.* && \
@@ -38,13 +35,6 @@ RUN rm datadog/createLogPath.sh && \
     rm -rf datadog/netstandard2.0 && \
     rm -rf datadog/netcoreapp3.1 && \
     rm -rf datadog/continuousprofiler
-
-# HACK: rename the tracer library so the logic in datadog_wrapper keeps working
-# See also https://github.com/DataDog/datadog-lambda-extension/pull/150
-#
-# We are doing this because the actual 'Datadog.Trace.ClrProfiler.Native.so' is a demux which calls this binary and 'Datadog.Trace.Profiler.so'.
-RUN if [ -f datadog/linux-x64/Datadog.Tracer.Native.so ]; then mv datadog/linux-x64/Datadog.Tracer.Native.so datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so; fi
-RUN if [ -f datadog/linux-arm64/Datadog.Tracer.Native.so ]; then mv datadog/linux-arm64/Datadog.Tracer.Native.so datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so; fi
 
 # add file with tracer version
 RUN echo ${TRACER_VERSION} > datadog/tracer_version.txt

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -35,7 +35,8 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -rf datadog/net461 && \
     rm -rf datadog/netstandard2.0 && \
     rm -rf datadog/netcoreapp3.1 && \
-    rm -rf datadog/continuousprofiler
+    rm -rf datadog/continuousprofiler \
+    rm -rf datadog/win-*
 
 # add file with tracer version
 RUN echo ${TRACER_VERSION} > datadog/tracer_version.txt

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -23,7 +23,6 @@ WORKDIR /opt
 RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/*.so && \
     rm -f datadog/loader.conf && \
-    rm -f datadog/**/loader.conf && \
     rm -f datadog/**/libddwaf.so && \
     rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
     rm -f datadog/**/Datadog.Profiler.Native.so && \

--- a/scripts/Dockerfile.benchmark
+++ b/scripts/Dockerfile.benchmark
@@ -1,4 +1,4 @@
-FROM ubuntu:latest as builder
+FROM ubuntu:latest AS builder
 ARG ARCH
 
 # make the args mandatory

--- a/scripts/Dockerfile.benchmark
+++ b/scripts/Dockerfile.benchmark
@@ -24,6 +24,7 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/**/*.xml && \
     rm -f datadog/dd-dotnet.sh && \
     rm -f datadog/**/dd-dotnet && \
+    rm -rf datadog/net461 && \
     rm -rf datadog/netstandard2.0 && \
     rm -rf datadog/netcoreapp3.1 && \
     rm -rf datadog/continuousprofiler

--- a/scripts/Dockerfile.benchmark
+++ b/scripts/Dockerfile.benchmark
@@ -19,6 +19,7 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
     rm -f datadog/**/Datadog.Profiler.Native.so && \
     rm -f datadog/**/Datadog.Trace.MSBuild.* && \
+    rm -f datadog/**/libdatadog_profiling.so \
     rm -f datadog/**/*.pdb && \
     rm -f datadog/**/*.xml && \
     rm -f datadog/dd-dotnet.sh && \

--- a/scripts/Dockerfile.benchmark
+++ b/scripts/Dockerfile.benchmark
@@ -17,7 +17,6 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/loader.conf && \
     rm -f datadog/**/loader.conf && \
     rm -f datadog/**/libddwaf.so && \
-    rm -f datadog/**/Datadog.Trace.ClrProfiler.Native.so && \
     rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
     rm -f datadog/**/Datadog.Profiler.Native.so && \
     rm -f datadog/**/Datadog.Trace.MSBuild.* && \
@@ -28,11 +27,6 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -rf datadog/netstandard2.0 && \
     rm -rf datadog/netcoreapp3.1 && \
     rm -rf datadog/continuousprofiler
-
-# HACK: rename the tracer library so the logic in datadog_wrapper keeps working
-# See also https://github.com/DataDog/datadog-lambda-extension/pull/150
-RUN if [ -f datadog/linux-x64/Datadog.Tracer.Native.so ]; then mv datadog/linux-x64/Datadog.Tracer.Native.so datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so; fi
-RUN if [ -f datadog/linux-arm64/Datadog.Tracer.Native.so ]; then mv datadog/linux-arm64/Datadog.Tracer.Native.so datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so; fi
 
 # zip the layer
 RUN mkdir /datadog

--- a/scripts/Dockerfile.benchmark
+++ b/scripts/Dockerfile.benchmark
@@ -15,7 +15,6 @@ COPY tracer-build datadog
 RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/*.so && \
     rm -f datadog/loader.conf && \
-    rm -f datadog/**/loader.conf && \
     rm -f datadog/**/libddwaf.so && \
     rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
     rm -f datadog/**/Datadog.Profiler.Native.so && \

--- a/scripts/Dockerfile.benchmark
+++ b/scripts/Dockerfile.benchmark
@@ -11,7 +11,7 @@ WORKDIR /opt
 # Copy current branch tracer build
 COPY tracer-build datadog
 
-# remove some useless files in a serverless context to keep the package as small as possible
+# remove files unused in a serverless context to keep the package as small as possible
 RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/*.so && \
     rm -f datadog/loader.conf && \

--- a/scripts/Dockerfile.benchmark
+++ b/scripts/Dockerfile.benchmark
@@ -27,7 +27,8 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -rf datadog/net461 && \
     rm -rf datadog/netstandard2.0 && \
     rm -rf datadog/netcoreapp3.1 && \
-    rm -rf datadog/continuousprofiler
+    rm -rf datadog/continuousprofiler \
+    rm -rf datadog/win-*
 
 # zip the layer
 RUN mkdir /datadog

--- a/scripts/Dockerfile.r2r
+++ b/scripts/Dockerfile.r2r
@@ -27,9 +27,6 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/loader.conf && \
     rm -f datadog/**/loader.conf && \
     rm -f datadog/**/libddwaf.so && \
-    # Revise to use 'Datadog.Trace.ClrProfiler.Native.so' for profiling, which calls
-    # 'Datadog.Trace.Native.so' and 'Datadog.Trace.Profiler.so'.
-    rm -f datadog/**/Datadog.Trace.ClrProfiler.Native.so && \
     rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
     rm -f datadog/**/Datadog.Profiler.Native.so && \
     rm -f datadog/**/Datadog.Trace.MSBuild.* && \
@@ -40,13 +37,6 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -rf datadog/netstandard2.0 && \
     rm -rf datadog/netcoreapp3.1 && \
     rm -rf datadog/continuousprofiler
-
-# HACK: rename the tracer library so the logic in datadog_wrapper keeps working
-# See also https://github.com/DataDog/datadog-lambda-extension/pull/150
-#
-# We are doing this because the actual 'Datadog.Trace.ClrProfiler.Native.so' is a demux which calls this binary and 'Datadog.Trace.Profiler.so'.
-RUN if [ -f datadog/linux-x64/Datadog.Tracer.Native.so ]; then mv datadog/linux-x64/Datadog.Tracer.Native.so datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so; fi
-RUN if [ -f datadog/linux-arm64/Datadog.Tracer.Native.so ]; then mv datadog/linux-arm64/Datadog.Tracer.Native.so datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so; fi
 
 # add file with tracer version
 RUN echo ${TRACER_VERSION} > datadog/tracer_version.txt

--- a/scripts/Dockerfile.r2r
+++ b/scripts/Dockerfile.r2r
@@ -25,7 +25,6 @@ RUN if [ "${ARCH}" = "arm64" ]; then cp -r artifacts/arm64/* datadog; fi
 RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/*.so && \
     rm -f datadog/loader.conf && \
-    rm -f datadog/**/loader.conf && \
     rm -f datadog/**/libddwaf.so && \
     rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
     rm -f datadog/**/Datadog.Profiler.Native.so && \

--- a/scripts/Dockerfile.r2r
+++ b/scripts/Dockerfile.r2r
@@ -37,7 +37,8 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -rf datadog/net461 && \
     rm -rf datadog/netstandard2.0 && \
     rm -rf datadog/netcoreapp3.1 && \
-    rm -rf datadog/continuousprofiler
+    rm -rf datadog/continuousprofiler \
+    rm -rf datadog/win-*
 
 # add file with tracer version
 RUN echo ${TRACER_VERSION} > datadog/tracer_version.txt

--- a/scripts/Dockerfile.r2r
+++ b/scripts/Dockerfile.r2r
@@ -21,7 +21,7 @@ RUN mkdir -p datadog
 RUN if [ "${ARCH}" = "amd64" ]; then cp -r artifacts/x64/* datadog; fi
 RUN if [ "${ARCH}" = "arm64" ]; then cp -r artifacts/arm64/* datadog; fi
 
-# remove some useless files in a serverless context to keep the package as small as possible
+# remove files unused in a serverless context to keep the package as small as possible
 RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/*.so && \
     rm -f datadog/loader.conf && \

--- a/scripts/Dockerfile.r2r
+++ b/scripts/Dockerfile.r2r
@@ -34,6 +34,7 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/**/*.xml && \
     rm -f datadog/dd-dotnet.sh && \
     rm -f datadog/**/dd-dotnet && \
+    rm -rf datadog/net461 && \
     rm -rf datadog/netstandard2.0 && \
     rm -rf datadog/netcoreapp3.1 && \
     rm -rf datadog/continuousprofiler

--- a/scripts/Dockerfile.r2r
+++ b/scripts/Dockerfile.r2r
@@ -29,6 +29,7 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
     rm -f datadog/**/Datadog.Profiler.Native.so && \
     rm -f datadog/**/Datadog.Trace.MSBuild.* && \
+    rm -f datadog/**/libdatadog_profiling.so \
     rm -f datadog/**/*.pdb && \
     rm -f datadog/**/*.xml && \
     rm -f datadog/dd-dotnet.sh && \

--- a/scripts/Dockerfile.sandbox
+++ b/scripts/Dockerfile.sandbox
@@ -34,6 +34,7 @@ RUN rm datadog/createLogPath.sh && \
     rm datadog/**/Datadog.Trace.MSBuild.* && \
     rm datadog/**/*.pdb && \
     rm datadog/**/*.xml && \
+    rm -rf datadog/net461 && \
     rm -rf datadog/netstandard2.0 && \
     rm -rf datadog/netcoreapp3.1 && \
     rm -rf datadog/continuousprofiler

--- a/scripts/Dockerfile.sandbox
+++ b/scripts/Dockerfile.sandbox
@@ -31,6 +31,7 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
     rm -f datadog/**/Datadog.Profiler.Native.so && \
     rm -f datadog/**/Datadog.Trace.MSBuild.* && \
+    rm -f datadog/**/libdatadog_profiling.so \
     rm -f datadog/**/*.pdb && \
     rm -f datadog/**/*.xml && \
     rm -rf datadog/net461 && \

--- a/scripts/Dockerfile.sandbox
+++ b/scripts/Dockerfile.sandbox
@@ -27,7 +27,6 @@ COPY /Datadog.Trace.dll /opt/datadog/net6.0/Datadog.Trace.dll
 RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/*.so && \
     rm -f datadog/loader.conf && \
-    rm -f datadog/**/loader.conf && \
     rm -f datadog/**/libddwaf.so && \
     rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
     rm -f datadog/**/Datadog.Profiler.Native.so && \

--- a/scripts/Dockerfile.sandbox
+++ b/scripts/Dockerfile.sandbox
@@ -37,7 +37,8 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -rf datadog/net461 && \
     rm -rf datadog/netstandard2.0 && \
     rm -rf datadog/netcoreapp3.1 && \
-    rm -rf datadog/continuousprofiler
+    rm -rf datadog/continuousprofiler \
+    rm -rf datadog/win-*
 
 # add file with tracer version
 RUN echo ${TRACER_VERSION} > datadog/tracer_version.txt

--- a/scripts/Dockerfile.sandbox
+++ b/scripts/Dockerfile.sandbox
@@ -24,16 +24,16 @@ RUN rm /opt/datadog/net6.0/Datadog.Trace.dll
 COPY /Datadog.Trace.dll /opt/datadog/net6.0/Datadog.Trace.dll
 
 # remove some useless files in a serverless context to keep the package as small as possible
-RUN rm datadog/createLogPath.sh && \
-    rm datadog/*.so && \
-    rm datadog/loader.conf && \
-    rm datadog/**/loader.conf && \
-    rm datadog/**/libddwaf.so && \
-    rm datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
-    rm datadog/**/Datadog.Profiler.Native.so && \
-    rm datadog/**/Datadog.Trace.MSBuild.* && \
-    rm datadog/**/*.pdb && \
-    rm datadog/**/*.xml && \
+RUN rm -f datadog/createLogPath.sh && \
+    rm -f datadog/*.so && \
+    rm -f datadog/loader.conf && \
+    rm -f datadog/**/loader.conf && \
+    rm -f datadog/**/libddwaf.so && \
+    rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
+    rm -f datadog/**/Datadog.Profiler.Native.so && \
+    rm -f datadog/**/Datadog.Trace.MSBuild.* && \
+    rm -f datadog/**/*.pdb && \
+    rm -f datadog/**/*.xml && \
     rm -rf datadog/net461 && \
     rm -rf datadog/netstandard2.0 && \
     rm -rf datadog/netcoreapp3.1 && \

--- a/scripts/Dockerfile.sandbox
+++ b/scripts/Dockerfile.sandbox
@@ -34,6 +34,8 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/**/libdatadog_profiling.so \
     rm -f datadog/**/*.pdb && \
     rm -f datadog/**/*.xml && \
+    rm -f datadog/dd-dotnet.sh && \
+    rm -f datadog/**/dd-dotnet && \
     rm -rf datadog/net461 && \
     rm -rf datadog/netstandard2.0 && \
     rm -rf datadog/netcoreapp3.1 && \

--- a/scripts/Dockerfile.sandbox
+++ b/scripts/Dockerfile.sandbox
@@ -1,4 +1,4 @@
-FROM ubuntu:latest as builder
+FROM ubuntu:latest AS builder
 ARG TRACER_VERSION
 ARG ARCH
 

--- a/scripts/Dockerfile.sandbox
+++ b/scripts/Dockerfile.sandbox
@@ -23,7 +23,7 @@ WORKDIR /opt
 RUN rm /opt/datadog/net6.0/Datadog.Trace.dll
 COPY /Datadog.Trace.dll /opt/datadog/net6.0/Datadog.Trace.dll
 
-# remove some useless files in a serverless context to keep the package as small as possible
+# remove files unused in a serverless context to keep the package as small as possible
 RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/*.so && \
     rm -f datadog/loader.conf && \

--- a/scripts/Dockerfile.sandbox
+++ b/scripts/Dockerfile.sandbox
@@ -29,7 +29,6 @@ RUN rm datadog/createLogPath.sh && \
     rm datadog/loader.conf && \
     rm datadog/**/loader.conf && \
     rm datadog/**/libddwaf.so && \
-    rm datadog/**/Datadog.Trace.ClrProfiler.Native.so && \
     rm datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
     rm datadog/**/Datadog.Profiler.Native.so && \
     rm datadog/**/Datadog.Trace.MSBuild.* && \
@@ -38,11 +37,6 @@ RUN rm datadog/createLogPath.sh && \
     rm -rf datadog/netstandard2.0 && \
     rm -rf datadog/netcoreapp3.1 && \
     rm -rf datadog/continuousprofiler
-
-# HACK: rename the tracer library so the logic in datadog_wrapper keeps working
-# See also https://github.com/DataDog/datadog-lambda-extension/pull/150
-RUN if [ -f datadog/linux-x64/Datadog.Tracer.Native.so ]; then mv datadog/linux-x64/Datadog.Tracer.Native.so datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so; fi
-RUN if [ -f datadog/linux-arm64/Datadog.Tracer.Native.so ]; then mv datadog/linux-arm64/Datadog.Tracer.Native.so datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so; fi
 
 # add file with tracer version
 RUN echo ${TRACER_VERSION} > datadog/tracer_version.txt


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

## What does this PR do?

- Stop removing the native loader library `Datadog.Trace.ClrProfiler.Native.so` (1.4MB) and its config file from the Lambda layer. Skipping the loader is not officially supported and can break Lambda if incompatible changes are made in `dd-trace-dotnet`.
  - Also stop renaming the native tracing library `Datadog.Tracer.Native.so` to `Datadog.Trace.ClrProfiler.Native.so` so it would get loaded by the Profiling API.
- Remove `libdatadog_profiling.so` (7.6MB) which is currently only used by Continuous Profiling, which is unsupported in AWS Lambda.
- Bonus 1: Just to be safe, try to also remove `net461/` and `win-*/`.
- Bonus 2: Add `.gitattributes` to set `*.sh` line endings to LF, even on Windows. Otherwise, execution of shell scripts inside Docker fails.

### All files
```
❯ du -s datadog-dotnet-apm_3.13.0_amd64
50992

❯ tree -F -h --sort size datadog-dotnet-apm_3.13.0_amd64
[4.0K]  datadog-dotnet-apm_3.13.0_amd64/
├── [4.0K]  opt/
│   └── [4.0K]  datadog/
│       ├── [2.4M]  libddwaf.so
│       ├── [1.4M]  Datadog.Trace.ClrProfiler.Native.so
│       ├── [4.0K]  continuousprofiler/
│       │   └── [ 18K]  Datadog.Linux.ApiWrapper.x64.so
│       ├── [4.0K]  linux-x64/
│       │   ├── [7.6M]  libdatadog_profiling.so
│       │   ├── [5.3M]  Datadog.Tracer.Native.so
│       │   ├── [3.8M]  dd-dotnet*
│       │   ├── [2.7M]  Datadog.Profiler.Native.so
│       │   ├── [2.4M]  libddwaf.so
│       │   ├── [1.4M]  Datadog.Trace.ClrProfiler.Native.so
│       │   ├── [ 18K]  Datadog.Linux.ApiWrapper.x64.so
│       │   └── [1.3K]  loader.conf
│       ├── [4.0K]  net6.0/
│       │   ├── [7.5M]  Datadog.Trace.dll
│       │   ├── [ 21K]  Datadog.Trace.MSBuild.dll
│       │   └── [8.5K]  Datadog.Trace.MSBuild.deps.json
│       ├── [4.0K]  netcoreapp3.1/
│       │   ├── [7.4M]  Datadog.Trace.dll
│       │   ├── [ 20K]  Datadog.Trace.MSBuild.dll
│       │   └── [8.5K]  Datadog.Trace.MSBuild.deps.json
│       ├── [4.0K]  netstandard2.0/
│       │   ├── [7.5M]  Datadog.Trace.dll
│       │   ├── [ 49K]  System.Threading.dll
│       │   ├── [ 43K]  System.Diagnostics.DiagnosticSource.dll
│       │   ├── [ 22K]  System.Reflection.Emit.ILGeneration.dll
│       │   ├── [ 22K]  System.Reflection.Emit.Lightweight.dll
│       │   ├── [ 22K]  System.Reflection.Emit.dll
│       │   ├── [ 20K]  Datadog.Trace.MSBuild.dll
│       │   └── [ 14K]  Datadog.Trace.MSBuild.deps.json
│       ├── [3.5K]  dd-dotnet.sh*
│       ├── [1.4K]  loader.conf
│       └── [ 101]  createLogPath.sh*
└── [4.0K]  usr/
    └── [4.0K]  share/
        └── [4.0K]  doc/
            └── [4.0K]  datadog-dotnet-apm/
                └── [ 919]  copyright
```

### Before this PR
```
❯ du -s datadog-dotnet-apm_3.13.0_amd64
20912

❯ tree -F -h --sort size datadog-dotnet-apm_3.13.0_amd64
[4.0K]  datadog-dotnet-apm_3.13.0_amd64/
├── [4.0K]  opt/
│   └── [4.0K]  datadog/
│       ├── [4.0K]  linux-x64/
│       │   ├── [7.6M]  libdatadog_profiling.so
│       │   └── [5.3M]  Datadog.Tracer.Native.so -> Datadog.Trace.ClrProfiler.Native.so
│       └── [4.0K]  net6.0/
│           └── [7.5M]  Datadog.Trace.dll
└── [4.0K]  usr/
    └── [4.0K]  share/
        └── [4.0K]  doc/
            └── [4.0K]  datadog-dotnet-apm/
                └── [ 919]  copyright
```

### After this PR
```diff
 ❯ du -s datadog-dotnet-apm_3.13.0_amd64
 14524

 ❯ tree -F -h --sort size datadog-dotnet-apm_3.13.0_amd64
 [4.0K]  datadog-dotnet-apm_3.13.0_amd64/
 ├── [4.0K]  opt/
 │   └── [4.0K]  datadog/
 │       ├── [4.0K]  linux-x64/
-│       │   ├── [7.6M]  libdatadog_profiling.so
 │       │   ├── [5.3M]  Datadog.Tracer.Native.so
+│       │   ├── [1.4M]  Datadog.Trace.ClrProfiler.Native.so
+│       │   └── [1.3K]  loader.conf
 │       └── [4.0K]  net6.0/
 │           └── [7.5M]  Datadog.Trace.dll
 └── [4.0K]  usr/
     └── [4.0K]  share/
         └── [4.0K]  doc/
             └── [4.0K]  datadog-dotnet-apm/
                 └── [ 919]  copyright
```

### Motivation

- Adding files: We need to keep the loader library to use `dd-trace-dotnet` in a supported manner.
- Removing files: We want to remove new unused files to keep the layer size as small as possible.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
