### PR TITLE
don't delete the native loader library

### DIFF
--- a/scripts/Dockerfile.r2r
+++ b/scripts/Dockerfile.r2r
@@ -18,8 +18,17 @@ COPY artifacts artifacts
 RUN mkdir -p datadog
 
 # Copy artifacts from the GitLab runner
-RUN if [ "${ARCH}" = "amd64" ]; then cp -r artifacts/x64/* datadog; mv datadog/Datadog.Trace.ClrProfiler.Native.so datadog/linux-x64; fi
-RUN if [ "${ARCH}" = "arm64" ]; then cp -r artifacts/arm64/* datadog; mv datadog/Datadog.Trace.ClrProfiler.Native.so datadog/linux-arm64; fi
+RUN if [ "${ARCH}" = "amd64" ]; then \
+      cp -r artifacts/x64/* datadog; \
+      mv datadog/Datadog.Trace.ClrProfiler.Native.so datadog/linux-x64; \
+      mv datadog/loader.conf datadog/linux-x64; \
+    fi
+
+RUN if [ "${ARCH}" = "arm64" ]; then \
+      cp -r artifacts/arm64/* datadog; \
+      mv datadog/Datadog.Trace.ClrProfiler.Native.so datadog/linux-arm64; \
+      mv datadog/loader.conf datadog/linux-arm64; \
+    fi
 
 # remove files unused in a serverless context to keep the package as small as possible
 RUN rm -f datadog/createLogPath.sh && \

--- a/scripts/Dockerfile.r2r
+++ b/scripts/Dockerfile.r2r
@@ -31,9 +31,7 @@ RUN if [ "${ARCH}" = "arm64" ]; then \
     fi
 
 # remove files unused in a serverless context to keep the package as small as possible
-RUN rm -f datadog/createLogPath.sh && \
-    rm -f datadog/*.so && \
-    rm -f datadog/loader.conf && \
+RUN rm -f datadog/**/createLogPath.sh && \
     rm -f datadog/**/libddwaf.so && \
     rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
     rm -f datadog/**/Datadog.Profiler.Native.so && \
@@ -41,7 +39,7 @@ RUN rm -f datadog/createLogPath.sh && \
     rm -f datadog/**/libdatadog_profiling.so \
     rm -f datadog/**/*.pdb && \
     rm -f datadog/**/*.xml && \
-    rm -f datadog/dd-dotnet.sh && \
+    rm -f datadog/**/dd-dotnet.sh && \
     rm -f datadog/**/dd-dotnet && \
     rm -rf datadog/net461 && \
     rm -rf datadog/netstandard2.0 && \

--- a/scripts/Dockerfile.r2r
+++ b/scripts/Dockerfile.r2r
@@ -10,7 +10,7 @@ RUN : "${TRACER_VERSION:?TRACER_VERSION needs to be provided}"
 RUN : "${ARCH:?ARCH needs to be provided}"
 
 RUN apt-get update && \
-    apt-get install -y zip curl
+    apt-get install -y zip
 
 WORKDIR /opt
 

--- a/scripts/Dockerfile.r2r
+++ b/scripts/Dockerfile.r2r
@@ -18,13 +18,15 @@ COPY artifacts artifacts
 RUN mkdir -p datadog
 
 # Copy artifacts from the GitLab runner
-RUN if [ "${ARCH}" = "amd64" ]; then cp -r artifacts/x64/* datadog; fi
-RUN if [ "${ARCH}" = "arm64" ]; then cp -r artifacts/arm64/* datadog; fi
+RUN if [ "${ARCH}" = "amd64" ]; then cp -r artifacts/x64/* datadog; mv datadog/Datadog.Trace.ClrProfiler.Native.so datadog/linux-x64; fi
+RUN if [ "${ARCH}" = "arm64" ]; then cp -r artifacts/arm64/* datadog; mv datadog/Datadog.Trace.ClrProfiler.Native.so datadog/linux-arm64; fi
 
 # remove files unused in a serverless context to keep the package as small as possible
 RUN rm -f datadog/createLogPath.sh && \
+    rm -f datadog/*.so && \
     rm -f datadog/loader.conf && \
     rm -f datadog/**/libddwaf.so && \
+    rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
     rm -f datadog/**/Datadog.Profiler.Native.so && \
     rm -f datadog/**/Datadog.Trace.MSBuild.* && \
     rm -f datadog/**/libdatadog_profiling.so \

--- a/scripts/Dockerfile.r2r
+++ b/scripts/Dockerfile.r2r
@@ -17,35 +17,34 @@ WORKDIR /opt
 COPY artifacts artifacts
 RUN mkdir -p datadog
 
-# Copy artifacts from the GitLab runner
 RUN if [ "${ARCH}" = "amd64" ]; then \
+      # Copy artifacts from the GitLab runner
       cp -r artifacts/x64/* datadog; \
+      # Move native files to the expected location
       mv datadog/Datadog.Trace.ClrProfiler.Native.so datadog/linux-x64; \
       mv datadog/loader.conf datadog/linux-x64; \
     fi
 
 RUN if [ "${ARCH}" = "arm64" ]; then \
+      # Copy artifacts from the GitLab runner
       cp -r artifacts/arm64/* datadog; \
+      # Move native files to the expected location
       mv datadog/Datadog.Trace.ClrProfiler.Native.so datadog/linux-arm64; \
       mv datadog/loader.conf datadog/linux-arm64; \
     fi
 
-# remove files unused in a serverless context to keep the package as small as possible
-RUN rm -f datadog/**/createLogPath.sh && \
-    rm -f datadog/**/libddwaf.so && \
-    rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
-    rm -f datadog/**/Datadog.Profiler.Native.so && \
-    rm -f datadog/**/Datadog.Trace.MSBuild.* && \
-    rm -f datadog/**/libdatadog_profiling.so \
-    rm -f datadog/**/*.pdb && \
-    rm -f datadog/**/*.xml && \
-    rm -f datadog/**/dd-dotnet.sh && \
-    rm -f datadog/**/dd-dotnet && \
-    rm -rf datadog/net461 && \
-    rm -rf datadog/netstandard2.0 && \
-    rm -rf datadog/netcoreapp3.1 && \
-    rm -rf datadog/continuousprofiler \
-    rm -rf datadog/win-*
+# remove files not used in AWS Lambda to keep the layer as small as possible
+RUN \
+    # Profiling and Crash Tracking
+    rm -f datadog/Datadog.Linux.ApiWrapper.x64.so && \
+    rm -f datadog/linux-*/libdatadog_profiling.so \
+    # AAP (formerly AppSec and ASM)
+    rm -f datadog/linux-*/libddwaf.so && \
+    # Test Optimization (CI Visibility)
+    rm -f datadog/net6.0/Datadog.Trace.MSBuild.* && \
+    # Debugger symbols and XML docs
+    rm -f datadog/net6.0/Datadog.Trace.pdb && \
+    rm -f datadog/net6.0/Datadog.Trace.xml
 
 # add file with tracer version
 RUN echo ${TRACER_VERSION} > datadog/tracer_version.txt

--- a/scripts/Dockerfile.r2r
+++ b/scripts/Dockerfile.r2r
@@ -23,10 +23,8 @@ RUN if [ "${ARCH}" = "arm64" ]; then cp -r artifacts/arm64/* datadog; fi
 
 # remove files unused in a serverless context to keep the package as small as possible
 RUN rm -f datadog/createLogPath.sh && \
-    rm -f datadog/*.so && \
     rm -f datadog/loader.conf && \
     rm -f datadog/**/libddwaf.so && \
-    rm -f datadog/**/Datadog.Linux.ApiWrapper.x64.so && \
     rm -f datadog/**/Datadog.Profiler.Native.so && \
     rm -f datadog/**/Datadog.Trace.MSBuild.* && \
     rm -f datadog/**/libdatadog_profiling.so \


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/dd-trace-dotnet-aws-lambda-layer/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Keep (don't delete) the native loader library `Datadog.Trace.ClrProfiler.Native.so` (1.5 MB) and it's `loader.conf` file.

### Motivation

<!--- What inspired you to submit this pull request? --->

Using the tracer without the native loader was never officially supported, and now it's required since `dd-trace-dotnet` v3.26.0 (see https://github.com/DataDog/dd-trace-dotnet/pull/7462).

### Testing Guidelines

<!--- How did you test this pull request? --->
Tracer should load and instrument as normal. Without these changes, it should fail to load.

### Additional Notes

- Fixes APMSVLS-174
- Note that [the paths are searched here](https://github.com/DataDog/datadog-lambda-extension/blob/983ce6f241b76ef0090fac180cf45d039ca73ea3/scripts/datadog_wrapper#L54-L63) and we need to keep backwards and forwards compatibility between versions of the two AWS Lambda layers.

New layout, where `linux-<arch>` is either `linux-x64` or `linux-arm64`:
```diff
 └── datadog
     ├── linux-<arch>
+    │   ├── Datadog.Trace.ClrProfiler.Native.so
     │   ├── Datadog.Tracer.Native.so
+    │   └── loader.conf
     ├── net6.0
     │   └── Datadog.Trace.dll
     └── tracer_version.txt
```


### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
