### PR TITLE
Adding image integrity signatures to Gitlab images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,9 @@ ci image:
   stage: build
   image: registry.ddbuild.io/images/docker:20.10
   tags: ["arch:arm64"]
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
   rules:
     - if: '$CI_COMMIT_BRANCH == "main" && $CI_PIPELINE_SOURCE == "push"'
       changes:
@@ -35,7 +38,9 @@ ci image:
   variables:
     DOCKER_TARGET: ${DOCKER_TARGET_IMAGE}:${DOCKER_TARGET_VERSION}
   script:
-    - docker buildx build --platform linux/amd64,linux/arm64 --no-cache --pull --push --tag ${DOCKER_TARGET} -f .gitlab/Dockerfile .
+    - METADATA_FILE=$(mktemp)
+    - docker buildx build --platform linux/amd64,linux/arm64 --no-cache --pull ---tag ${DOCKER_TARGET} -f .gitlab/Dockerfile -push --metadata-file ${METADATA_FILE} .
+    - ddsign sign ${DOCKER_TARGET} --docker-metadata-file ${METADATA_FILE}
 
 generator:
   stage: pre


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/dd-trace-dotnet-aws-lambda-layer/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Adds image integrity signature for registry.ddbuild.io/ci/dd-trace-dotnet-aws-lambda-layer Gitlab image.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
Compliance
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
