### PR TITLE
fix: grant testing account access to sandbox layers

### DIFF
--- a/.gitlab/scripts/publish_layers.sh
+++ b/.gitlab/scripts/publish_layers.sh
@@ -25,13 +25,21 @@ publish_layer() {
         | jq -r '.Version'
     )
 
-    # Add permissions only for prod and gov-prod
+    # Add permissions: public for prod, grant testing account access to sandbox layers
     if [ "$STAGE" == "prod" ] || [ "$STAGE" == "gov-prod" ]; then
         permission=$(aws lambda add-layer-version-permission --layer-name $layer \
             --version-number $version_nbr \
             --statement-id "release-$version_nbr" \
             --action lambda:GetLayerVersion \
             --principal "*" \
+            --region $region
+        )
+    else
+        permission=$(aws lambda add-layer-version-permission --layer-name $layer \
+            --version-number $version_nbr \
+            --statement-id "release-$version_nbr" \
+            --action lambda:GetLayerVersion \
+            --principal "093468662994" \
             --region $region
         )
     fi


### PR DESCRIPTION
## Summary
- Sandbox layers were published without any permissions, blocking the self-monitoring account (`093468662994`) from accessing dev layer versions during CDK deployments.
- When publishing to sandbox, the publish script now grants `lambda:GetLayerVersion` to the testing account.

## Test plan
- [ ] Trigger a sandbox layer publish and verify the layer has a resource-based policy for `093468662994`