### PR TITLE
ci: migrate CI secrets from AWS SSM to Vault KV

### DIFF
--- a/.gitlab/scripts/get_secrets.sh
+++ b/.gitlab/scripts/get_secrets.sh
@@ -21,21 +21,11 @@ fi
 
 printf "Getting AWS External ID...\n"
 
-EXTERNAL_ID=$(aws ssm get-parameter \
-    --region us-east-1 \
-    --name "ci.dd-trace-dotnet-aws-lambda-layer.$EXTERNAL_ID_NAME" \
-    --with-decryption \
-    --query "Parameter.Value" \
-    --out text)
+EXTERNAL_ID=$(vault kv get -field="$EXTERNAL_ID_NAME" kv/k8s/gitlab-runner/dd-trace-dotnet-aws-lambda-layer/secrets)
 
 printf "Getting DD API KEY...\n"
 
-export DD_API_KEY=$(aws ssm get-parameter \
-    --region us-east-1 \
-    --name ci.dd-trace-dotnet-aws-lambda-layer.dd-api-key \
-    --with-decryption \
-    --query "Parameter.Value" \
-    --out text)
+export DD_API_KEY=$(vault kv get -field=dd-api-key kv/k8s/gitlab-runner/dd-trace-dotnet-aws-lambda-layer/secrets)
 
 printf "Assuming role...\n"
 


### PR DESCRIPTION
## Summary
- Migrate `get_secrets.sh` from `aws ssm get-parameter` to `vault kv get`, aligning with the pattern used by `datadog-lambda-js`

## Test plan
- [ ] Verify CI pipeline can fetch secrets from Vault KV at `kv/k8s/gitlab-runner/dd-trace-dotnet-aws-lambda-layer/secrets`
- [ ] Confirm `DD_API_KEY` and external ID are correctly resolved