### PR TITLE
Add .NET 10 as compatible runtime

### DIFF
--- a/.gitlab/scripts/publish_layers.sh
+++ b/.gitlab/scripts/publish_layers.sh
@@ -18,7 +18,7 @@ publish_layer() {
 
     version_nbr=$(aws lambda publish-layer-version --layer-name $layer \
         --description "dd-trace-dotnet" \
-        --compatible-runtimes "dotnet6" "dotnet8" \
+        --compatible-runtimes "dotnet6" "dotnet8" "dotnet10" \
         --compatible-architectures $compatible_architectures \
         --zip-file "fileb://${file}" \
         --region $region \


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/dd-trace-dotnet-aws-lambda-layer/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Adds .NET 10 as compatible runtime when publishing layer, as .NET 10 is supported with tracer v3.31.0+

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
